### PR TITLE
19 use curationmetric object to store trace metrics

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -121,13 +121,9 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
 
     for roi_id in range(N):
         cell_plots[roi_id] = f"plots/{experiment_id}_{roi_id}_oasis.png"
-    print("CELL PLOTS")
-    print([json.dumps(cell_plots)])
     curation = CurationMetric(
-        value=[json.dumps(cell_plots)]
+        curations=[json.dumps(cell_plots)]
     )
-    print("~~~~~~~~~~~~~~~CURATION")
-    print(curation)
     metric = QCMetric(
         name=f"{experiment_id} {roi_id} Event Detection",
         description="",

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -144,7 +144,7 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
         tags=["events"],
     )
 
-    with open(output_dir / f"{experiment_id}_evaluation.json", "w") as f:
+    with open(output_dir / f"{experiment_id}_oasis_events_evaluation.json", "w") as f:
         json.dump(json.loads(evaluation.model_dump_json()), f, indent=4)
 
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -121,9 +121,13 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
 
     for roi_id in range(N):
         cell_plots[roi_id] = f"plots/{experiment_id}_{roi_id}_oasis.png"
+    print("CELL PLOTS")
+    print([json.dumps(cell_plots)])
     curation = CurationMetric(
         value=[json.dumps(cell_plots)]
     )
+    print("~~~~~~~~~~~~~~~CURATION")
+    print(curation)
     metric = QCMetric(
         name=f"{experiment_id} {roi_id} Event Detection",
         description="",

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -123,9 +123,9 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
         cell_plots[roi_id] = f"plots/{experiment_id}_{roi_id}_oasis.png"
     curation = CurationMetric(curations=[json.dumps(cell_plots)])
     metric = QCMetric(
-        name=f"{experiment_id} {roi_id} Event Detection",
-        description="",
-        reference=str(f"plots/{experiment_id}_{roi_id}_oasis.png"),
+        name=f"{experiment_id} Event Detection",
+        description="dF / F and roi events detected by oasis",
+        reference="",
         status_history=[
             QCStatus(evaluator="Automated", timestamp=dt.now(), status=Status.PASS)
         ],

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -12,7 +12,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 from aind_data_schema.core.processing import DataProcess, ProcessName
-from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status
+from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status, Stage, QCEvaluation
+from aind_data_schema_models.modalities import Modality
 from aind_log_utils.log import setup_logging
 from aind_qcportal_schema.metric_value import CurationMetric, DropdownMetric
 from oasis.functions import deconvolve
@@ -131,8 +132,19 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
         ],
         value=curation,
     )
-    with open(output_dir / f"{experiment_id}_events_metric.json", "w") as f:
-        json.dump(json.loads(metric.model_dump_json()), f, indent=4)
+
+    evaluation = QCEvaluation(
+        modality=Modality.from_abbreviation("pophys"),
+        stage=Stage.PROCESSING,
+        name="Events",
+        description="Events detected in each roi for all fovs",
+        allow_failed_metrics=False,
+        metrics=[metric],
+        tags=["events"],
+    )
+
+    with open(output_dir / f"{experiment_id}_evaluation.json", "w") as f:
+        json.dump(json.loads(evaluation.model_dump_json()), f, indent=4)
 
 
 def get_metadata(input_dir: Path, meta_type: str) -> dict:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -12,7 +12,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 from aind_data_schema.core.processing import DataProcess, ProcessName
-from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status, Stage, QCEvaluation
+from aind_data_schema.core.quality_control import (QCEvaluation, QCMetric,
+                                                   QCStatus, Stage, Status)
 from aind_data_schema_models.modalities import Modality
 from aind_log_utils.log import setup_logging
 from aind_qcportal_schema.metric_value import CurationMetric, DropdownMetric

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -14,7 +14,7 @@ import seaborn as sns
 from aind_data_schema.core.processing import DataProcess, ProcessName
 from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status
 from aind_log_utils.log import setup_logging
-from aind_qcportal_schema.metric_value import DropdownMetric, CurationMetric
+from aind_qcportal_schema.metric_value import CurationMetric, DropdownMetric
 from oasis.functions import deconvolve
 from oasis.oasis_methods import oasisAR1, oasisAR1_f32, oasisAR2
 
@@ -121,9 +121,7 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
 
     for roi_id in range(N):
         cell_plots[roi_id] = f"plots/{experiment_id}_{roi_id}_oasis.png"
-    curation = CurationMetric(
-        curations=[json.dumps(cell_plots)]
-    )
+    curation = CurationMetric(curations=[json.dumps(cell_plots)])
     metric = QCMetric(
         name=f"{experiment_id} {roi_id} Event Detection",
         description="",
@@ -133,9 +131,7 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
         ],
         value=curation,
     )
-    with open(
-        output_dir / f"{experiment_id}_events_metric.json", "w"
-    ) as f:
+    with open(output_dir / f"{experiment_id}_events_metric.json", "w") as f:
         json.dump(json.loads(metric.model_dump_json()), f, indent=4)
 
 
@@ -161,6 +157,7 @@ def get_metadata(input_dir: Path, meta_type: str) -> dict:
         metadata = json.load(f)
     return metadata
 
+
 def get_frame_rate(session: dict) -> float:
     """Attempt to pull frame rate from session.json
     Raises ValueError if frame rate not in session.json
@@ -185,6 +182,7 @@ def get_frame_rate(session: dict) -> float:
     if isinstance(frame_rate_hz, str):
         frame_rate_hz = float(frame_rate_hz)
     return frame_rate_hz
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -14,7 +14,7 @@ import seaborn as sns
 from aind_data_schema.core.processing import DataProcess, ProcessName
 from aind_data_schema.core.quality_control import QCMetric, QCStatus, Status
 from aind_log_utils.log import setup_logging
-from aind_qcportal_schema.metric_value import DropdownMetric
+from aind_qcportal_schema.metric_value import DropdownMetric, CurationMetric
 from oasis.functions import deconvolve
 from oasis.oasis_methods import oasisAR1, oasisAR1_f32, oasisAR2
 
@@ -117,32 +117,26 @@ def write_qc_metrics(output_dir: Path, experiment_id: str, N: int) -> None:
     N: int
         number of ROIs detected
     """
+    cell_plots = dict()
 
     for roi_id in range(N):
-        metric = QCMetric(
-            name=f"{experiment_id} {roi_id} Event Detection",
-            description="",
-            reference=str(f"plots/{experiment_id}_{roi_id}_oasis.png"),
-            status_history=[
-                QCStatus(evaluator="Automated", timestamp=dt.now(), status=Status.PASS)
-            ],
-            value=DropdownMetric(
-                value="Reasonable",
-                options=[
-                    "Reasonable",
-                    "Unreasonable",
-                ],
-                status=[
-                    Status.PASS,
-                    Status.FAIL,
-                ],
-            ),
-        )
-
-        with open(
-            output_dir / f"{experiment_id}_{roi_id}_events_metric.json", "w"
-        ) as f:
-            json.dump(json.loads(metric.model_dump_json()), f, indent=4)
+        cell_plots[roi_id] = f"plots/{experiment_id}_{roi_id}_oasis.png"
+    curation = CurationMetric(
+        value=[json.dumps(cell_plots)]
+    )
+    metric = QCMetric(
+        name=f"{experiment_id} {roi_id} Event Detection",
+        description="",
+        reference=str(f"plots/{experiment_id}_{roi_id}_oasis.png"),
+        status_history=[
+            QCStatus(evaluator="Automated", timestamp=dt.now(), status=Status.PASS)
+        ],
+        value=curation,
+    )
+    with open(
+        output_dir / f"{experiment_id}_events_metric.json", "w"
+    ) as f:
+        json.dump(json.loads(metric.model_dump_json()), f, indent=4)
 
 
 def get_metadata(input_dir: Path, meta_type: str) -> dict:

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -21,6 +21,6 @@ RUN pip install -U --no-cache-dir \
     oasis-deconv==0.2.0 \
     pydantic==2.8.2 \
     seaborn==0.12.2 \
-    aind-data-schema==1.1.0 \
+    aind-data-schema==1.2.0 \
     aind-log-utils \
     aind-qcportal-schema


### PR DESCRIPTION
Add `CurationMetric` as a metric to bundle all the plots output from oasis event detection. This should improve performance when viewing these images in the qc portal